### PR TITLE
Adapt sync_eyelink to be applied run-wise and add run to file names

### DIFF
--- a/mne_bids_pipeline/steps/preprocessing/_05b_sync_eyelink.py
+++ b/mne_bids_pipeline/steps/preprocessing/_05b_sync_eyelink.py
@@ -465,7 +465,5 @@ def main(*, config: SimpleNamespace) -> None:
                 task=task,
             )
             for subject, session, run, task in ssrt
-            # for subject in get_subjects(config)
-            # for session in get_sessions(config)
         )
     save_logs(config=config, logs=logs)

--- a/mne_bids_pipeline/steps/preprocessing/_05b_sync_eyelink.py
+++ b/mne_bids_pipeline/steps/preprocessing/_05b_sync_eyelink.py
@@ -13,6 +13,7 @@ from ..._config_utils import (
     get_runs,
     get_sessions,
     get_subjects,
+    _get_ssrt,
 )
 from ..._import_data import annotations_to_events, make_epochs
 from ..._logging import gen_log_kwargs, logger
@@ -68,6 +69,8 @@ def get_input_fnames_sync_eyelink(
     cfg: SimpleNamespace,
     subject: str,
     session: str | None,
+    run: str,
+    task: str | None,
 ) -> dict:
     
     # Get from config file whether `task` is specified in the et file name
@@ -79,6 +82,7 @@ def get_input_fnames_sync_eyelink(
     bids_basename = BIDSPath(
         subject=subject,
         session=session,
+        run=run,
         task=cfg.task,
         acquisition=cfg.acq,
         recording=cfg.rec,
@@ -116,14 +120,23 @@ def get_input_fnames_sync_eyelink(
     )
 
     in_files = dict()
-    for run in cfg.runs:
-        key = f"raw_run-{run}"
-        in_files[key] = bids_basename.copy().update(
-            run=run, processing=cfg.processing, suffix="raw"
-        )
-        _update_for_splits(in_files, key, single=True)
 
-        et_bids_basename_temp = et_asc_bids_basename.copy()
+    key = f"raw_run-{run}"
+    in_files[key] = bids_basename.copy().update(
+        processing=cfg.processing, suffix="raw"
+    )
+
+    et_bids_basename_temp = et_asc_bids_basename.copy()
+
+    if cfg.et_has_run:
+        et_bids_basename_temp.update(run=run)
+
+    # _update_for_splits(in_files, key, single=True) # TODO: Find out if we need to add this or not
+
+    if not os.path.isfile(et_bids_basename_temp):
+        logger.info(**gen_log_kwargs(message=f"Couldn't find {et_bids_basename_temp} file. If edf file exists, edf2asc will be called."))
+
+        et_bids_basename_temp = et_edf_bids_basename.copy()
 
         if cfg.et_has_run:
             et_bids_basename_temp.update(run=run)
@@ -131,21 +144,11 @@ def get_input_fnames_sync_eyelink(
         # _update_for_splits(in_files, key, single=True) # TODO: Find out if we need to add this or not
 
         if not os.path.isfile(et_bids_basename_temp):
-            logger.info(**gen_log_kwargs(message=f"Couldn't find {et_bids_basename_temp} file. If edf file exists, edf2asc will be called."))
+            logger.error(**gen_log_kwargs(message=f"Also didn't find {et_bids_basename_temp} file, one of both needs to exist for ET sync."))
+            raise FileNotFoundError(f"For run {run}, could neither find .asc or .edf eye-tracking file. Please double-check the file names.")
 
-            et_bids_basename_temp = et_edf_bids_basename.copy()
-
-            if cfg.et_has_run:
-                et_bids_basename_temp.update(run=run)
-
-            # _update_for_splits(in_files, key, single=True) # TODO: Find out if we need to add this or not
-
-            if not os.path.isfile(et_bids_basename_temp):
-                logger.error(**gen_log_kwargs(message=f"Also didn't find {et_bids_basename_temp} file, one of both needs to exist for ET sync."))
-                raise FileNotFoundError(f"For run {run}, could neither find .asc or .edf eye-tracking file. Please double-check the file names.")
-
-        key = f"et_run-{run}"
-        in_files[key] = et_bids_basename_temp
+    key = f"et_run-{run}"
+    in_files[key] = et_bids_basename_temp
   
     return in_files
 
@@ -160,6 +163,8 @@ def sync_eyelink(
     exec_params: SimpleNamespace,
     subject: str,
     session: str | None,
+    run: str,
+    task: str | None,
     in_files: dict,
 ) -> dict:
     
@@ -167,11 +172,11 @@ def sync_eyelink(
     import matplotlib.pyplot as plt
     from scipy.signal import correlate
 
-    raw_fnames = [in_files.pop(f"raw_run-{run}") for run in cfg.runs]
-    et_fnames = [in_files.pop(f"et_run-{run}") for run in cfg.runs]
-    logger.info(**gen_log_kwargs(message=f"Found the following eye-tracking files: {et_fnames}"))
+    raw_fname = in_files.pop(f"raw_run-{run}")
+    et_fname = in_files.pop(f"et_run-{run}")
+    logger.info(**gen_log_kwargs(message=f"Found the following eye-tracking files: {et_fname}"))
     out_files = dict()
-    bids_basename = raw_fnames[0].copy().update(processing=None, split=None, run=None) #TODO: Do we need to remove the run here?
+    bids_basename = raw_fname.copy().update(processing=None, split=None) #TODO: Do we need the `split=None` here?
     out_files["eyelink_eeg"] = bids_basename.copy().update(processing="eyelink", suffix="raw")
     del bids_basename
 
@@ -184,126 +189,125 @@ def sync_eyelink(
     out_dir_beh /= "beh"
     out_dir_beh.mkdir(exist_ok=True, parents=True) # TODO: Check whether the parameter settings make sense or if there is a danger that something could be accidentally overwritten
 
-    out_files["eyelink_et_events"] = et_fnames[0].copy().update(root=cfg.deriv_root, suffix="et_events", extension=".tsv")
+    out_files["eyelink_et_events"] = et_fname.copy().update(root=cfg.deriv_root, suffix="et_events", extension=".tsv")
     
-    for idx, (run, raw_fname,et_fname) in enumerate(zip(cfg.runs, raw_fnames,et_fnames)):
-        msg = f"Syncing Eyelink ({et_fname.basename}) and EEG data ({raw_fname.basename})."
-        logger.info(**gen_log_kwargs(message=msg))
-        raw = mne.io.read_raw_fif(raw_fname, preload=True)
+    msg = f"Syncing Eyelink ({et_fname.basename}) and EEG data ({raw_fname.basename})."
+    logger.info(**gen_log_kwargs(message=msg))
+    raw = mne.io.read_raw_fif(raw_fname, preload=True)
 
-        et_format = et_fname.extension
+    et_format = et_fname.extension
 
-        if not et_format == '.asc':
-            assert et_format == '.edf', "ET file is neither an `.asc` nor an `.edf`. This should not have happened."
-            logger.info(**gen_log_kwargs(message=f"Converting {et_fname} file to `.asc` using edf2asc."))
-            import subprocess
-            subprocess.run(["edf2asc", et_fname]) # TODO: Still needs to be tested
-            et_fname.update(extension='.asc')
+    if not et_format == '.asc':
+        assert et_format == '.edf', "ET file is neither an `.asc` nor an `.edf`. This should not have happened."
+        logger.info(**gen_log_kwargs(message=f"Converting {et_fname} file to `.asc` using edf2asc."))
+        import subprocess
+        subprocess.run(["edf2asc", et_fname]) # TODO: Still needs to be tested
+        et_fname.update(extension='.asc')
 
-        raw_et = mne.io.read_raw_eyelink(et_fname, find_overlaps=False) # TODO: Make find_overlaps optional
+    raw_et = mne.io.read_raw_eyelink(et_fname, find_overlaps=False) # TODO: Make find_overlaps optional
 
-        # If the user did not specify a regular expression for the eye-tracking sync events, it is assumed that it's
-        # identical to the regex for the EEG sync events
-        if not cfg.sync_eventtype_regex_et:
-            cfg.sync_eventtype_regex_et = cfg.sync_eventtype_regex
-        
-        et_sync_times = [annotation["onset"] for annotation in raw_et.annotations if re.search(cfg.sync_eventtype_regex_et,annotation["description"])]
-        sync_times    = [annotation["onset"] for annotation in raw.annotations    if re.search(cfg.sync_eventtype_regex,   annotation["description"])]
-        assert len(et_sync_times) == len(sync_times),f"Detected eyetracking and EEG sync events were not of equal size ({len(et_sync_times)} vs {len(sync_times)}). Adjust your regular expressions via 'sync_eventtype_regex_et' and 'sync_eventtype_regex' accordingly"
-        #logger.info(**gen_log_kwargs(message=f"{et_sync_times}"))
-        #logger.info(**gen_log_kwargs(message=f"{sync_times}"))
+    # If the user did not specify a regular expression for the eye-tracking sync events, it is assumed that it's
+    # identical to the regex for the EEG sync events
+    if not cfg.sync_eventtype_regex_et:
+        cfg.sync_eventtype_regex_et = cfg.sync_eventtype_regex
+    
+    et_sync_times = [annotation["onset"] for annotation in raw_et.annotations if re.search(cfg.sync_eventtype_regex_et,annotation["description"])]
+    sync_times    = [annotation["onset"] for annotation in raw.annotations    if re.search(cfg.sync_eventtype_regex,   annotation["description"])]
+    assert len(et_sync_times) == len(sync_times),f"Detected eyetracking and EEG sync events were not of equal size ({len(et_sync_times)} vs {len(sync_times)}). Adjust your regular expressions via 'sync_eventtype_regex_et' and 'sync_eventtype_regex' accordingly"
+    #logger.info(**gen_log_kwargs(message=f"{et_sync_times}"))
+    #logger.info(**gen_log_kwargs(message=f"{sync_times}"))
 
 
-        # Check whether the eye-tracking data contains nan values. If yes replace them with zeros.
-        if np.isnan(raw_et.get_data()).any():
+    # Check whether the eye-tracking data contains nan values. If yes replace them with zeros.
+    if np.isnan(raw_et.get_data()).any():
 
-            # Set all nan values in the eye-tracking data to 0 (to make resampling possible)
-            # TODO: Decide whether this is a good approach or whether interpolation (e.g. of blinks) is useful
-            # TODO: Decide about setting the values (e.g. for blinks) back to nan after synchronising the signals
-            # TODO: Tip: With `mne.preprocessing.annotate_nan` you could get the timings comparatively easy, and then after `realign_raw` put nans on top.
-            np.nan_to_num(raw_et._data, copy=False, nan=0.0)
-            logger.info(**gen_log_kwargs(message=f"The eye-tracking data contained nan values. They were replaced with zeros."))
+        # Set all nan values in the eye-tracking data to 0 (to make resampling possible)
+        # TODO: Decide whether this is a good approach or whether interpolation (e.g. of blinks) is useful
+        # TODO: Decide about setting the values (e.g. for blinks) back to nan after synchronising the signals
+        # TODO: Tip: With `mne.preprocessing.annotate_nan` you could get the timings comparatively easy, and then after `realign_raw` put nans on top.
+        np.nan_to_num(raw_et._data, copy=False, nan=0.0)
+        logger.info(**gen_log_kwargs(message=f"The eye-tracking data contained nan values. They were replaced with zeros."))
 
-        #mne.preprocessing.eyetracking.interpolate_blinks(raw_et, buffer=(0.05, 0.05), interpolate_gaze=True)        
+    #mne.preprocessing.eyetracking.interpolate_blinks(raw_et, buffer=(0.05, 0.05), interpolate_gaze=True)        
 
-        # Align the data
-        mne.preprocessing.realign_raw(raw, raw_et, sync_times, et_sync_times)
+    # Align the data
+    mne.preprocessing.realign_raw(raw, raw_et, sync_times, et_sync_times)
 
-        # Add ET data to EEG
-        raw.add_channels([raw_et], force_update_info=True)
+    # Add ET data to EEG
+    raw.add_channels([raw_et], force_update_info=True)
 
-        # Also add ET annotations to EEG
-        # first mark et sync event descriptions so we can differentiate them later
-        # TODO: For now all ET events will be marked with ET and added to the EEG annotations, maybe later filter for certain events only
-        raw_et.annotations.description = np.array(list(map(lambda desc: "ET_" + desc, raw_et.annotations.description)))
-        raw.set_annotations(mne.annotations._combine_annotations(raw.annotations,
-                                                                 raw_et.annotations,
-                                                                 0,
-                                                                 raw.first_samp,
-                                                                 raw_et.first_samp,
-                                                                 raw.info["sfreq"]))
+    # Also add ET annotations to EEG
+    # first mark et sync event descriptions so we can differentiate them later
+    # TODO: For now all ET events will be marked with ET and added to the EEG annotations, maybe later filter for certain events only
+    raw_et.annotations.description = np.array(list(map(lambda desc: "ET_" + desc, raw_et.annotations.description)))
+    raw.set_annotations(mne.annotations._combine_annotations(raw.annotations,
+                                                                raw_et.annotations,
+                                                                0,
+                                                                raw.first_samp,
+                                                                raw_et.first_samp,
+                                                                raw.info["sfreq"]))
 
-        msg = f"Saving synced data to disk."
-        logger.info(**gen_log_kwargs(message=msg))
-        raw.save(
-            out_files["eyelink_eeg"],
-            overwrite=True,
-            split_naming="bids", # TODO: Find out if we need to add this or not
-            split_size=cfg._raw_split_size, # ???
-        )
-        # no idea what the split stuff is...
-        _update_for_splits(out_files, "eyelink_eeg") # TODO: Find out if we need to add this or not
+    msg = f"Saving synced data to disk."
+    logger.info(**gen_log_kwargs(message=msg))
+    raw.save(
+        out_files["eyelink_eeg"],
+        overwrite=True,
+        split_naming="bids", # TODO: Find out if we need to add this or not
+        split_size=cfg._raw_split_size, # ???
+    )
+    # no idea what the split stuff is...
+    # _update_for_splits(out_files, "eyelink_eeg") # TODO: Find out if we need to add this or not
 
-        # Extract and concatenate eye-tracking event data frames
-        et_dfs = raw_et._raw_extras[0]["dfs"]
-        df_list = [] # List to collect extracted data frames before concatenation
+    # Extract and concatenate eye-tracking event data frames
+    et_dfs = raw_et._raw_extras[0]["dfs"]
+    df_list = [] # List to collect extracted data frames before concatenation
 
-        # Extract fixations, saccades and blinks data frames
-        for df_name, trial_type in zip(["fixations", "saccades", "blinks"], ["fixation", "saccade", "blink"]):
-            df = et_dfs[df_name]
-            df["trial_type"] = trial_type
-            df_list.append(df)
+    # Extract fixations, saccades and blinks data frames
+    for df_name, trial_type in zip(["fixations", "saccades", "blinks"], ["fixation", "saccade", "blink"]):
+        df = et_dfs[df_name]
+        df["trial_type"] = trial_type
+        df_list.append(df)
 
-        et_combined_df = pd.concat(df_list, ignore_index=True)
-        et_combined_df.rename(columns={"time":"onset"}, inplace=True)
-        et_combined_df.sort_values(by="onset", inplace=True, ignore_index=True)
-        et_combined_df = et_combined_df[ # Adapt column order
-            [
-                "onset", # needs to be first (BIDS convention)
-                "duration",
-                "end_time",
-                "trial_type",
-                "eye",
-                "fix_avg_x",
-                "fix_avg_y",
-                "fix_avg_pupil_size",
-                "sacc_start_x",
-                "sacc_start_y",
-                "sacc_end_x",
-                "sacc_end_y",
-                "sacc_visual_angle",
-                "peak_velocity"
-            ]
-        ] 
+    et_combined_df = pd.concat(df_list, ignore_index=True)
+    et_combined_df.rename(columns={"time":"onset"}, inplace=True)
+    et_combined_df.sort_values(by="onset", inplace=True, ignore_index=True)
+    et_combined_df = et_combined_df[ # Adapt column order
+        [
+            "onset", # needs to be first (BIDS convention)
+            "duration",
+            "end_time",
+            "trial_type",
+            "eye",
+            "fix_avg_x",
+            "fix_avg_y",
+            "fix_avg_pupil_size",
+            "sacc_start_x",
+            "sacc_start_y",
+            "sacc_end_x",
+            "sacc_end_y",
+            "sacc_visual_angle",
+            "peak_velocity"
+        ]
+    ] 
 
-        # Synchronize eye-tracking events with EEG data
+    # Synchronize eye-tracking events with EEG data
 
-        # Recalculate regression coefficients (because the realign_raw function does not output them)
-        # Code snippet from `mne.preprocessing.realign_raw` function:
-        # https://github.com/mne-tools/mne-python/blob/b44c46ae7f9b6ffc5318b5d64f12906c1f2d875c/mne/preprocessing/realign.py#L69-L71
-        poly = Polynomial.fit(x=et_sync_times, y=sync_times, deg=1)
-        converted = poly.convert(domain=(-1, 1))
-        [zero_ord, first_ord] = converted.coef
-        # print(zero_ord, first_ord)
+    # Recalculate regression coefficients (because the realign_raw function does not output them)
+    # Code snippet from `mne.preprocessing.realign_raw` function:
+    # https://github.com/mne-tools/mne-python/blob/b44c46ae7f9b6ffc5318b5d64f12906c1f2d875c/mne/preprocessing/realign.py#L69-L71
+    poly = Polynomial.fit(x=et_sync_times, y=sync_times, deg=1)
+    converted = poly.convert(domain=(-1, 1))
+    [zero_ord, first_ord] = converted.coef
+    # print(zero_ord, first_ord)
 
-        # Synchronize time stamps of ET events
-        et_combined_df["onset"] = (et_combined_df["onset"] * first_ord + zero_ord)
-        et_combined_df["end_time"] = (et_combined_df["end_time"] * first_ord + zero_ord)
-        # TODO: To be super correct, we would need to recalculate duration column as well - but typically the slope is so close to "1" that this would typically result in <1ms differences
+    # Synchronize time stamps of ET events
+    et_combined_df["onset"] = (et_combined_df["onset"] * first_ord + zero_ord)
+    et_combined_df["end_time"] = (et_combined_df["end_time"] * first_ord + zero_ord)
+    # TODO: To be super correct, we would need to recalculate duration column as well - but typically the slope is so close to "1" that this would typically result in <1ms differences
 
-        msg = f"Saving synced eye-tracking events to disk."
-        logger.info(**gen_log_kwargs(message=msg))
-        et_combined_df.to_csv(out_files["eyelink_et_events"], sep="\t", index=False)
+    msg = f"Saving synced eye-tracking events to disk."
+    logger.info(**gen_log_kwargs(message=msg))
+    et_combined_df.to_csv(out_files["eyelink_et_events"], sep="\t", index=False)
 
     # Add to report
     fig, axes = plt.subplots(2, 2, figsize=(19.2, 19.2))
@@ -394,6 +398,7 @@ def sync_eyelink(
         exec_params=exec_params,
         subject=subject,
         session=session,
+        run=run,
         task=cfg.task,
     ) as report:
         caption = caption
@@ -447,17 +452,20 @@ def main(*, config: SimpleNamespace) -> None:
         logger.info(**gen_log_kwargs(message=msg, emoji="skip"))
         return
 
-
+    ssrt = _get_ssrt(config=config)
     with get_parallel_backend(config.exec_params):
-        parallel, run_func = parallel_func(sync_eyelink, exec_params=config.exec_params)
+        parallel, run_func = parallel_func(sync_eyelink, exec_params=config.exec_params, n_iter=len(ssrt))
         logs = parallel(
             run_func(
                 cfg=get_config(config=config, subject=subject),
                 exec_params=config.exec_params,
                 subject=subject,
                 session=session,
+                run=run,
+                task=task,
             )
-            for subject in get_subjects(config)
-            for session in get_sessions(config)
+            for subject, session, run, task in ssrt
+            # for subject in get_subjects(config)
+            # for session in get_sessions(config)
         )
     save_logs(config=config, logs=logs)


### PR DESCRIPTION
Adapt functions in `_05b_sync_eyelink.py` to work run-wise and not loop through all runs in one function call. 
Reasons:
- Make the code more similar to the other mne-bids-pipeline scripts
- Fix the bug that script will only work for run 1 + that run is not added to the out_file names.