### PR TITLE
Fix ICA fitting by changing picks to 'data'

### DIFF
--- a/mne_bids_pipeline/steps/preprocessing/_06a1_fit_ica.py
+++ b/mne_bids_pipeline/steps/preprocessing/_06a1_fit_ica.py
@@ -291,8 +291,8 @@ def run_ica(
         fit_params=fit_params,
         max_iter=cfg.ica_max_iterations,
     )
-    # TODO: This works for our pipeline (exclude eye-tracking data for ICA) but probably not in general
-    ica.fit(epochs.pick(picks="eeg"), decim=cfg.ica_decim)
+    # TODO: THis is breaking because EOGs are excluded by setting the picks
+    ica.fit(picks='data', decim=cfg.ica_decim)
     explained_var = (
         ica.pca_explained_variance_[: ica.n_components_].sum()
         / ica.pca_explained_variance_.sum()


### PR DESCRIPTION
Updated ICA fitting to exclude EOGs and use 'data' picks.

### Before merging …

- [ ] Changelog has been updated (`docs/source/dev.md.inc`)
