### PR TITLE
better NAN-Handling

### DIFF
--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -939,6 +939,14 @@ For full documatation of the bandpass filter:
 https://mne.tools/stable/generated/mne.filter.filter_data
 """
 
+ica_filter_extra_kws: dict[str, Any] = {}
+"""
+A dictionary of extra kwargs to pass to `mne.filter.filter` for the ICA. If kwargs
+are passed here that have dedicated config settings already, an error will be raised.
+For full documentation of the ICA filter:
+https://mne.tools/stable/generated/mne.filter.filter_data
+"""
+
 # ### Resampling
 #
 # If you have acquired data with a very high sampling frequency (e.g. 2 kHz)

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -1678,6 +1678,9 @@ ica_remove_nan: bool = True
 """
 Annotate all nan's and remove them for the ICA fit. 
 This is implemented via mne.annotate_nan, which adds BAD_NAN annotations.
+
+This setting also overwrites the `skip_by_annotation` key in `ica_filter_extra_kws` 
+to `{"skip_by_annotation":"BAD_NAN"}`
 """
 
 ica_use_ecg_detection: bool = True

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -1674,6 +1674,12 @@ it is to run but the less data you have to compute a good ICA. Set to
 `1` or `None` to not perform any decimation.
 """
 
+ica_remove_nan: bool = True
+"""
+Annotate all nan's and remove them for the ICA fit. 
+This is implemented via mne.annotate_nan, which adds BAD_NAN annotations.
+"""
+
 ica_use_ecg_detection: bool = True
 """
 Whether to use the MNE ECG detection on the ICA components.

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -1676,11 +1676,14 @@ it is to run but the less data you have to compute a good ICA. Set to
 
 ica_skip_nan: bool = True
 """
-Annotate all nan's and skip them for the ICA fit. 
+Annotate all nan's prior to ICA fit, and skip them for the ICA fit. 
 This is implemented via mne.annotate_nan, which adds BAD_NAN annotations.
 
-This setting also overwrites the `skip_by_annotation` key in `ica_filter_extra_kws` 
-to `{"skip_by_annotation":"BAD_NAN"}`
+The user should think whether they want to set `ica_filter_extra_kws` to
+ `{"skip_by_annotation":"BAD_NAN"}` (and the respective `bandpass_extra_kws`
+ and `notch_extra_kws`). If they are not, NANs are "propagating" to the
+ filter window length. If they are set, filter-artefacts at the boundaries
+ to the NANs might be introduced.
 """
 
 ica_use_ecg_detection: bool = True

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -1674,9 +1674,9 @@ it is to run but the less data you have to compute a good ICA. Set to
 `1` or `None` to not perform any decimation.
 """
 
-ica_remove_nan: bool = True
+ica_skip_nan: bool = True
 """
-Annotate all nan's and remove them for the ICA fit. 
+Annotate all nan's and skip them for the ICA fit. 
 This is implemented via mne.annotate_nan, which adds BAD_NAN annotations.
 
 This setting also overwrites the `skip_by_annotation` key in `ica_filter_extra_kws` 

--- a/mne_bids_pipeline/steps/preprocessing/_06a1_fit_ica.py
+++ b/mne_bids_pipeline/steps/preprocessing/_06a1_fit_ica.py
@@ -207,8 +207,6 @@ def run_ica(
         if cfg.ica_l_freq is not None or h_freq is not None:
             
             extra_kws = dict(cfg.ica_filter_extra_kws or {})
-            if cfg.ica_skip_nan:
-                extra_kws["skip_by_annotation"] = ["BAD_NAN"]
             raw.filter(l_freq=cfg.ica_l_freq, h_freq=h_freq, n_jobs=1, **extra_kws)
 
         # Only keep the subset of the mapping that applies to the current run

--- a/mne_bids_pipeline/steps/preprocessing/_06a1_fit_ica.py
+++ b/mne_bids_pipeline/steps/preprocessing/_06a1_fit_ica.py
@@ -35,7 +35,28 @@ from mne_bids_pipeline._run import (
     save_logs,
 )
 from mne_bids_pipeline.typing import InFilesT, OutFilesT
+from matplotlib.patches import Rectangle
+import matplotlib.pyplot as plt
 
+def visualize_bad_nan(annotations):
+    """Simple visualization of BAD_NAN annotations with scatter for others"""
+    fig, ax = plt.subplots(figsize=(10, 0.5))
+    
+    for ann in annotations:
+        if ann['description'] == 'BAD_NAN':
+            # Draw rectangle for BAD_NAN segments
+            rect = Rectangle((ann['onset'], 0), ann['duration'], 1, 
+                        facecolor='blue', alpha=0.7)
+            ax.add_patch(rect)
+        else:
+            # Draw scatter point for other annotations
+            ax.scatter(ann['onset'], 0.5, c='green', s=50, marker='o')
+    
+    
+    ax.set_ylim(0, 1)
+    ax.set_xlabel('Time (s)')
+    ax.set_yticks([])
+    return fig
 
 def get_input_fnames_run_ica(
     *,
@@ -103,12 +124,14 @@ def run_ica(
     # across all runs.
     event_name_to_code_map = annotations_to_events(raw_paths=raw_fnames)
 
+    
     epochs = None
     for idx, (run, raw_fname) in enumerate(zip(cfg.runs, raw_fnames)):
         msg = f"Processing raw data from {raw_fname.basename}"
         logger.info(**gen_log_kwargs(message=msg))
         raw = mne.io.read_raw_fif(raw_fname)
         picks = raw.get_channel_types(unique=True)
+
         # if we have M/EEG data but only want to process EEG data, we need to remove
         # the EEG data here to avoid issues with ICA application later.
         # picking just the cfg.datatype will exclude stuff like EOG channels that
@@ -116,6 +139,34 @@ def run_ica(
         if "eeg" not in cfg.datatype and "eeg" in picks:
             picks.remove("eeg")
         raw.pick(picks=picks).load_data()
+
+        nan_annotations = mne.preprocessing.annotate_nan(raw) if cfg.ica_remove_nan else None
+        if nan_annotations is not None:
+            logger.info(**gen_log_kwargs(message=f"Found {len(nan_annotations)} NaN segments in the data. These will be annotated as BAD_NAN and ignored for ICA fitting."))
+            raw.set_annotations(raw.annotations + nan_annotations)
+
+        if cfg.ica_remove_nan:
+            fig = visualize_bad_nan(raw.annotations)
+            with _open_report(
+                cfg=cfg,
+                exec_params=exec_params,
+                subject=subject,
+                session=session,
+                run=run,
+                task=cfg.task,
+            ) as report:
+                caption = "Visualization of BAD_NAN annotations (in blue) that were automatically added to the raw data before ICA fitting. These segments contained NaN values and were ignored for ICA fitting. Other annotations are shown as green dots."
+                report.add_figure(
+                    fig=fig,
+                    title="BAD_NAN annotations for ICA fitting",
+                    section="ICA: nan removal",
+                    caption=caption,
+                    tags=("ica", "nan"),
+                    replace=True,
+                )
+                plt.close(fig)
+
+
 
         # Produce high-pass filtered version of the data for ICA.
         # Sanity check – make sure we're using the correct data!
@@ -334,6 +385,7 @@ def run_ica(
             replace=True,
             tags=tags,
         )
+            
         if cfg.ica_reject == "autoreject_local":
             assert ar_reject_log is not None
             caption = (
@@ -380,6 +432,7 @@ def get_config(
         ica_decim=config.ica_decim,
         ica_reject=config.ica_reject,
         ica_use_icalabel=config.ica_use_icalabel,
+        ica_remove_nan = config.ica_remove_nan,
         autoreject_n_interpolate=config.autoreject_n_interpolate,
         random_state=config.random_state,
         ch_types=config.ch_types,

--- a/mne_bids_pipeline/steps/preprocessing/_06a1_fit_ica.py
+++ b/mne_bids_pipeline/steps/preprocessing/_06a1_fit_ica.py
@@ -140,12 +140,12 @@ def run_ica(
             picks.remove("eeg")
         raw.pick(picks=picks).load_data()
 
-        nan_annotations = mne.preprocessing.annotate_nan(raw) if cfg.ica_remove_nan else None
+        nan_annotations = mne.preprocessing.annotate_nan(raw) if cfg.ica_skip_nan else None
         if nan_annotations is not None:
             logger.info(**gen_log_kwargs(message=f"Found {len(nan_annotations)} NaN segments in the data. These will be annotated as BAD_NAN and ignored for ICA fitting."))
             raw.set_annotations(raw.annotations + nan_annotations)
 
-        if cfg.ica_remove_nan:
+        if cfg.ica_skip_nan:
             fig = visualize_bad_nan(raw.annotations)
             with _open_report(
                 cfg=cfg,
@@ -207,7 +207,7 @@ def run_ica(
         if cfg.ica_l_freq is not None or h_freq is not None:
             
             extra_kws = dict(cfg.ica_filter_extra_kws or {})
-            if cfg.ica_remove_nan:
+            if cfg.ica_skip_nan:
                 extra_kws["skip_by_annotation"] = ["BAD_NAN"]
             raw.filter(l_freq=cfg.ica_l_freq, h_freq=h_freq, n_jobs=1, **extra_kws)
 
@@ -436,7 +436,7 @@ def get_config(
         ica_decim=config.ica_decim,
         ica_reject=config.ica_reject,
         ica_use_icalabel=config.ica_use_icalabel,
-        ica_remove_nan = config.ica_remove_nan,
+        ica_skip_nan = config.ica_skip_nan,
         autoreject_n_interpolate=config.autoreject_n_interpolate,
         random_state=config.random_state,
         ch_types=config.ch_types,

--- a/mne_bids_pipeline/steps/preprocessing/_06a1_fit_ica.py
+++ b/mne_bids_pipeline/steps/preprocessing/_06a1_fit_ica.py
@@ -154,7 +154,7 @@ def run_ica(
             del nyq
 
         if cfg.ica_l_freq is not None or h_freq is not None:
-            raw.filter(l_freq=cfg.ica_l_freq, h_freq=h_freq, n_jobs=1)
+            raw.filter(l_freq=cfg.ica_l_freq, h_freq=h_freq, n_jobs=1,**cfg.ica_filter_extra_kws)
 
         # Only keep the subset of the mapping that applies to the current run
         event_id = event_name_to_code_map.copy()
@@ -399,6 +399,7 @@ def get_config(
         rest_epochs_overlap=config.rest_epochs_overlap,
         processing="eyelink" if config.sync_eyelink else "filt" if config.regress_artifact is None else "regress",
         _epochs_split_size=config._epochs_split_size,
+        ica_filter_extra_kws = config.ica_filter_extra_kws,
         **_bids_kwargs(config=config),
     )
     return cfg

--- a/mne_bids_pipeline/steps/preprocessing/_06a1_fit_ica.py
+++ b/mne_bids_pipeline/steps/preprocessing/_06a1_fit_ica.py
@@ -205,7 +205,11 @@ def run_ica(
             del nyq
 
         if cfg.ica_l_freq is not None or h_freq is not None:
-            raw.filter(l_freq=cfg.ica_l_freq, h_freq=h_freq, n_jobs=1,**cfg.ica_filter_extra_kws)
+            
+            extra_kws = dict(cfg.ica_filter_extra_kws or {})
+            if cfg.ica_remove_nan:
+                extra_kws["skip_by_annotation"] = ["BAD_NAN"]
+            raw.filter(l_freq=cfg.ica_l_freq, h_freq=h_freq, n_jobs=1, **extra_kws)
 
         # Only keep the subset of the mapping that applies to the current run
         event_id = event_name_to_code_map.copy()

--- a/mne_bids_pipeline/steps/preprocessing/_07_make_epochs.py
+++ b/mne_bids_pipeline/steps/preprocessing/_07_make_epochs.py
@@ -258,6 +258,15 @@ def run_epochs(
         logger.info(**gen_log_kwargs(message=msg))
         # Add PSD plots for 30s of data or all epochs if we have less available
         psd = True if len(epochs) * (epochs.tmax - epochs.tmin) < 30 else 30.0
+
+        # handle NANs for plotting
+        import numpy as np
+        epochs.drop_bad(
+            reject={"eeg": lambda x: (
+                np.isnan(x).any(),  # This returns a single boolean
+                "NaN detected in EEG data",
+            )}
+        )
         report.add_epochs(
             epochs=epochs,
             title="Epochs: before cleaning",

--- a/mne_bids_pipeline/steps/preprocessing/_08a_apply_ica.py
+++ b/mne_bids_pipeline/steps/preprocessing/_08a_apply_ica.py
@@ -168,6 +168,14 @@ def apply_ica_epochs(
         kwargs["emoji"] = "skip"
     logger.info(**gen_log_kwargs(message=msg, **kwargs))
     if ica.exclude:
+                # handle NANs for plotting
+        import numpy as np
+        epochs.drop_bad(
+            reject={"eeg": lambda x: (
+                np.isnan(x).any(),  # This returns a single boolean
+                "NaN detected in EEG data",
+            )}
+        )
         with _open_report(
             cfg=cfg,
             exec_params=exec_params,

--- a/mne_bids_pipeline/steps/preprocessing/_09_ptp_reject.py
+++ b/mne_bids_pipeline/steps/preprocessing/_09_ptp_reject.py
@@ -225,7 +225,14 @@ def drop_ptp(
                 replace=True,
                 tags=tags,
             )
-
+        # handle NANs for plotting
+        import numpy as np
+        epochs.drop_bad(
+            reject={"eeg": lambda x: (
+                np.isnan(x).any(),  # This returns a single boolean
+                "NaN detected in EEG data",
+            )}
+        )
         report.add_epochs(
             epochs=epochs,
             title=title,


### PR DESCRIPTION
- **added kwargs for ICA-filter**
- **added automatic NAN removal before ICA**
- **automatically activate the skipping**
- **renamed from remove to skip**

This PR adds an optional nan_annotate step before ICA. If it finds NANs, they are automatically skipped - also a visual report is added depicting the periods with NANs (it is ommited if no nans are found)
### Before merging …

- [ ] Changelog has been updated (`docs/source/dev.md.inc`)
