### PR TITLE
Add bad channel overview table

### DIFF
--- a/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
+++ b/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
@@ -288,21 +288,56 @@ def assess_data_quality(
             report.remove(title=title)
             report.add_html(text_html, **text_kwargs)
         if cfg.pyprep_bad_chans:
+            import pdb
+            pdb.set_trace()
             raw.set_annotations(None) # annotations only bother us here
             msg = "Adding pyprep bad channels to report"
             logger.info(**gen_log_kwargs(message=msg))
-            for k, v in pyprep_bads.items():
-                raw.info["bads"] = v
-                if not v or k == "all_bads":
-                    continue
-                _add_raw(
-                    cfg=cfg,
-                    report=report,
-                    bids_path_in=bids_path_in,
-                    title=f"Raw, algorithm {k}",
-                    tags=("bad_channel",),
-                    raw=raw,
-                )
+
+            # Reshape from long to wide format
+            bad_channels_df = pd.pivot_table(tsv_data, columns="reason", index="name", aggfunc=lambda x: True, fill_value=False)
+            color_map = lambda x: 'background-color: #FFB3B3' if x else 'background-color: #B3B3FF' # Colour-code whether a channel was marked as bad by an algorithm
+            styled_df = bad_channels_df.style.map(color_map)
+
+            # Convert pandas df to html table and do some formatting
+            bad_channels_html = styled_df.to_html(header=False)
+            styled_html = f"""
+            <div style="width:100%; overflow-x:auto;">
+                <style>
+                    table {{ width: 100%; }}
+                    th, td {{
+                        min-width: 100px;
+                        padding: 10px;
+                    }}
+                </style>
+                {bad_channels_html}
+            </div>
+            """
+            report.add_html(section="Bad channel detection using PyPREP", title="Bad channel detection overview", html=styled_html)
+            raw.info["bads"] = pyprep_bads["bad_all"]
+            _add_raw(
+                cfg=cfg,
+                report=report,
+                bids_path_in=bids_path_in,
+                section="Bad channel detection using PyPREP",
+                title=f"Raw, bad_all",
+                tags=tags+["bad_channel"],
+                raw=raw,
+            )
+
+
+            # for k, v in pyprep_bads.items():
+            #     raw.info["bads"] = v
+            #     if not v or k == "all_bads":
+            #         continue
+            #     _add_raw(
+            #         cfg=cfg,
+            #         report=report,
+            #         bids_path_in=bids_path_in,
+            #         title=f"Raw, algorithm {k}",
+            #         tags=("bad_channel",),
+            #         raw=raw,
+            #     )
 
     assert len(in_files) == 0, in_files.keys()
     return _prep_out_files(exec_params=exec_params, out_files=out_files)

--- a/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
+++ b/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
@@ -288,8 +288,6 @@ def assess_data_quality(
             report.remove(title=title)
             report.add_html(text_html, **text_kwargs)
         if cfg.pyprep_bad_chans:
-            import pdb
-            pdb.set_trace()
             raw.set_annotations(None) # annotations only bother us here
             msg = "Adding pyprep bad channels to report"
             logger.info(**gen_log_kwargs(message=msg))
@@ -313,15 +311,18 @@ def assess_data_quality(
                 {bad_channels_html}
             </div>
             """
-            report.add_html(section="Bad channel detection using PyPREP", title="Bad channel detection overview", html=styled_html)
+            report.add_html(
+                section="Bad channel detection using PyPREP",
+                title="Bad channel detection overview",
+                tags=tags+("bad_channel",),
+                html=styled_html)
             raw.info["bads"] = pyprep_bads["bad_all"]
             _add_raw(
                 cfg=cfg,
                 report=report,
                 bids_path_in=bids_path_in,
-                section="Bad channel detection using PyPREP",
                 title=f"Raw, bad_all",
-                tags=tags+["bad_channel"],
+                tags=("bad_channel",),
                 raw=raw,
             )
 


### PR DESCRIPTION
This PR:
- adds a bad channel overview table to the report which lists which channels were classified as bad by which algorithms.
   Example: 
   <img width="1982" height="373" alt="grafik" src="https://github.com/user-attachments/assets/0aa64ba5-fe37-4022-8e0f-aea44189e43f" />
- changes the previous plotting code from plotting time series + raw for all algorithms seperately to only plotting it once for `bad_all` (to reduce plotting time and because I had the impression that the plots were not super helpful for me; but of course open to debate).

This addresses some aspects from this issue: https://github.com/s-ccs/mne-bids-eyetracking-pipeline/issues/18

However what still could be improved in the future is:
- At the moment the table is based on the information that is saved in the `_bads.tsv` file and thereby only includes methods that actually classified any channel as bad. The downside of this is that it's unclear whether a channel was not flagged as bad by an algorithm or whether the algorithm was just not run.
- There could be a better data visualisation of the bad channels' data than the one provided by `_add_raw` but I don't have time to improve this right now.
- There could be a better handling for the case that there are no bad channels detected for the report. At the moment, the result in the report looks like this, which is not super nice. I'd imagine checking whether the respective df or list is empty and if yes just display some text instead of the table.
  
<img width="308" height="153" alt="grafik" src="https://github.com/user-attachments/assets/727fa1f6-ddc8-4694-9691-6ba63a1d04b0" />
