### PR TITLE
add more options(event matching, trigger filtering) for break detection

### DIFF
--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -591,6 +591,52 @@ pre-stimulus period as bad.
     ```
 """
 
+break_start_regex: str | None = None
+"""
+Regular expression matching the annotation descriptions that mark the **start**
+of a break period (marker-based break detection). If both this and
+[`break_end_regex`][mne_bids_pipeline._config.break_end_regex] are set, breaks
+are detected by pairing these markers instead of by gap detection.
+
+For data with `block_start`/`block_end` markers, note that a break *starts*
+when a block *ends*, so this should match the block-end trigger.
+
+???+ example "Example"
+```python
+    break_start_regex = r"block\\d+_end"
+```
+"""
+
+break_end_regex: str | None = None
+"""
+Regular expression matching the annotation descriptions that mark the **end**
+of a break period (marker-based break detection). See
+[`break_start_regex`][mne_bids_pipeline._config.break_start_regex]. For
+`block_start`/`block_end` data this should match the block-start trigger, as a
+break *ends* when the next block *begins*.
+
+???+ example "Example"
+```python
+    break_end_regex = r"block\\d+_start"
+```
+"""
+
+task_event_regex: str | None = None
+"""
+Regular expression selecting the task events to keep when detecting breaks by
+gaps. Only annotations whose description matches are considered "real" events;
+everything else (e.g. regular synchronization pulses that would otherwise fill
+every gap) is ignored, so breaks re-emerge as long event-free spans. Used only
+when [`break_start_regex`][mne_bids_pipeline._config.break_start_regex] and
+[`break_end_regex`][mne_bids_pipeline._config.break_end_regex] are not set.
+
+???+ example "Example"
+```python
+    task_event_regex = r"stimulus/.*"
+```
+"""
+
+
 # %%
 # ## Bad channel detection
 #

--- a/mne_bids_pipeline/_import_data.py
+++ b/mne_bids_pipeline/_import_data.py
@@ -5,6 +5,7 @@ from typing import Any, Literal
 import mne
 import numpy as np
 import pandas as pd
+import re
 from mne_bids import BIDSPath, get_bids_path_from_fname, read_raw_bids
 
 from ._config_utils import (
@@ -553,19 +554,113 @@ def _find_breaks_func(
     if not cfg.find_breaks:
         return
 
-    msg = f"Finding breaks with a minimum duration of {cfg.min_break_duration} seconds."
+    if cfg.break_start_regex and cfg.break_end_regex:
+        _find_breaks_func_by_markers(cfg=cfg, raw=raw, subject=subject, session=session, run=run)
+    else:
+        _find_breaks_func_by_gaps(cfg=cfg, raw=raw, subject=subject, session=session, run=run)
+
+
+def _find_breaks_func_by_gaps(
+    *,
+    cfg: SimpleNamespace,
+    raw: mne.io.BaseRaw,
+    subject: str,
+    session: str | None,
+    run: str | None,
+) -> None:
+
+    events = None
+    if cfg.task_event_regex is not None:
+        msg = (
+            f"Finding breaks with a minimum duration of {cfg.min_break_duration} seconds, "
+            f"while ignoring triggers except for those that match the regex {cfg.task_event_regex}."
+        )
+        try:
+            events, _  = mne.events_from_annotations(raw, regexp=cfg.task_event_regex)
+        except ValueError:
+            logger.warning(**gen_log_kwargs(message=f"No annotations matched the provided task_event_regex ({cfg.task_event_regex}). "))
+            return
+    else:
+        msg = f"Finding breaks with a minimum duration of {cfg.min_break_duration} seconds."
     logger.info(**gen_log_kwargs(message=msg))
 
     break_annots = mne.preprocessing.annotate_break(
         raw=raw,
+        events=events, 
         min_break_duration=cfg.min_break_duration,
         t_start_after_previous=cfg.t_break_annot_start_after_previous_event,
-        t_stop_before_next=cfg.t_break_annot_stop_before_next_event,
+        t_stop_before_next=cfg.t_break_annot_stop_before_next_event
     )
 
     msg = (
         f"Found and annotated "
         f"{len(break_annots) if break_annots else 'no'} break periods."
+    )
+    logger.info(**gen_log_kwargs(message=msg))
+
+    raw.set_annotations(raw.annotations + break_annots)  # add to existing
+
+
+def _find_breaks_func_by_markers(
+    *,
+    cfg: SimpleNamespace,
+    raw: mne.io.BaseRaw,
+    subject: str,
+    session: str | None,
+    run: str | None,
+) -> None:
+
+    msg = f"Finding breaks between markers {cfg.break_start_regex} and {cfg.break_end_regex}."
+    logger.info(**gen_log_kwargs(message=msg))
+
+    # Look for the timesteps where the specified break markers occer in the annotations
+    starts, ends = [], []
+    for annot in raw.annotations:
+        if re.search(cfg.break_start_regex, annot["description"]):
+            starts.append(annot["onset"])
+        elif re.search(cfg.break_end_regex, annot["description"]):
+            ends.append(annot["onset"])
+
+    if not starts or not ends:
+        logger.info(**gen_log_kwargs(
+            message=f"No complete break periods found(starts: {len(starts)}, ends: {len(ends)}); nothing to annotate."))
+        return
+
+    # pair up starts and ends to create break annotations
+    onsets, durations, annotations = [], [], []
+    rec_start = raw.first_time
+    rec_end = raw.first_time + raw.times[-1]
+
+    # mark the breaks in between
+    for i, start in enumerate(starts):
+        end = next((e for e in ends if e > start), None)
+        next_start = starts[i + 1] if i + 1 < len(starts) else None
+
+        if i == 0 and ends[0] < start:
+            onsets.append(rec_start)
+            durations.append(ends[0] - rec_start)
+            annotations.append("BAD_beginning")
+        if next_start is not None and (end is None or next_start < end):  # if the next start comes before the end, we have an unmatched start
+            msg = (
+                f"Found a break start at {start:.2f}s that is not followed by a break end. "
+                f"Not annotated until the next break start at {next_start:.2f}s."
+            )
+            logger.warning(**gen_log_kwargs(message=msg))
+        elif end is not None:
+            onsets.append(start)
+            durations.append(end - start)
+            annotations.append("BAD_break")
+        else:
+            onsets.append(start)
+            durations.append(rec_end - start)
+            annotations.append("BAD_ending")            
+
+    # convert to mne Annotations object
+    break_annots = mne.Annotations(onset=onsets, duration=durations, description=annotations, orig_time=raw.annotations.orig_time)
+
+    msg = (
+        f"Found and annotated "
+        f"{len(break_annots) if break_annots else 'no'} break periods (including the beginning and end of the recording if applicable)."
     )
     logger.info(**gen_log_kwargs(message=msg))
 
@@ -870,6 +965,9 @@ def _import_data_kwargs(*, config: SimpleNamespace, subject: str) -> dict[str, A
         min_break_duration=config.min_break_duration,
         t_break_annot_start_after_previous_event=config.t_break_annot_start_after_previous_event,  # noqa:E501
         t_break_annot_stop_before_next_event=config.t_break_annot_stop_before_next_event,  # noqa:E501
+        break_start_regex=config.break_start_regex,
+        break_end_regex=config.break_end_regex,
+        task_event_regex=config.task_event_regex,
         # 6. _rename_events_func
         rename_events=config.rename_events,
         on_rename_missing_events=config.on_rename_missing_events,

--- a/mne_bids_pipeline/_import_data.py
+++ b/mne_bids_pipeline/_import_data.py
@@ -1,3 +1,4 @@
+from numba.core.ir import Return
 from collections.abc import Iterable
 from types import SimpleNamespace
 from typing import Any, Literal
@@ -598,7 +599,7 @@ def _find_breaks_func_by_gaps(
     )
     logger.info(**gen_log_kwargs(message=msg))
 
-    raw.set_annotations(raw.annotations + break_annots)  # add to existing
+    raw.set_annotations(raw.annotations + break_annots)
 
 
 def _find_breaks_func_by_markers(
@@ -621,10 +622,23 @@ def _find_breaks_func_by_markers(
         elif re.search(cfg.break_end_regex, annot["description"]):
             ends.append(annot["onset"])
 
+    # If there are no complete break periods, log a message and return early
     if not starts or not ends:
         logger.info(**gen_log_kwargs(
             message=f"No complete break periods found(starts: {len(starts)}, ends: {len(ends)}); nothing to annotate."))
         return
+
+    # Check for consecutive starts or ends and log warnings if found
+    markers = sorted([(o, "start") for o in starts] + [(o, "end") for o in ends])
+    for (onset_prev, kind_prev), (onset_cur, kind_cur) in zip(markers, markers[1:]):
+        if kind_prev == "start" and kind_cur == "start":
+            logger.warning(**gen_log_kwargs(message=(
+                f"Found two break starts in a row (~{onset_prev:.2f}s and ~{onset_cur:.2f}s); "
+                f"Not annotated until the next break start at {onset_cur:.2f}s. Manual inspection recommended.")))
+        elif kind_prev == "end" and kind_cur == "end":
+            logger.warning(**gen_log_kwargs(message=(
+                f"Found two break ends in a row (~{onset_prev:.2f}s and ~{onset_cur:.2f}s); "
+                f"a break start may be missing, so that break was not annotated. Manual inspection recommended.")))
 
     # pair up starts and ends to create break annotations
     onsets, durations, annotations = [], [], []
@@ -641,11 +655,7 @@ def _find_breaks_func_by_markers(
             durations.append(ends[0] - rec_start)
             annotations.append("BAD_beginning")
         if next_start is not None and (end is None or next_start < end):  # if the next start comes before the end, we have an unmatched start
-            msg = (
-                f"Found a break start at {start:.2f}s that is not followed by a break end. "
-                f"Not annotated until the next break start at {next_start:.2f}s."
-            )
-            logger.warning(**gen_log_kwargs(message=msg))
+            continue  # skip this start, as it is unmatched
         elif end is not None:
             onsets.append(start)
             durations.append(end - start)
@@ -655,7 +665,6 @@ def _find_breaks_func_by_markers(
             durations.append(rec_end - start)
             annotations.append("BAD_ending")            
 
-    # convert to mne Annotations object
     break_annots = mne.Annotations(onset=onsets, duration=durations, description=annotations, orig_time=raw.annotations.orig_time)
 
     msg = (
@@ -664,7 +673,7 @@ def _find_breaks_func_by_markers(
     )
     logger.info(**gen_log_kwargs(message=msg))
 
-    raw.set_annotations(raw.annotations + break_annots)  # add to existing
+    raw.set_annotations(raw.annotations + break_annots) 
 
 
 def _get_bids_path_in(

--- a/mne_bids_pipeline/_import_data.py
+++ b/mne_bids_pipeline/_import_data.py
@@ -1,4 +1,3 @@
-from numba.core.ir import Return
 from collections.abc import Iterable
 from types import SimpleNamespace
 from typing import Any, Literal

--- a/mne_bids_pipeline/tests/test_breaks.py
+++ b/mne_bids_pipeline/tests/test_breaks.py
@@ -1,0 +1,140 @@
+import numpy as np
+import mne
+import pytest
+from types import SimpleNamespace
+from mne_bids_pipeline._import_data import _find_breaks_func
+
+def make_raw(annots, duration=300.0, sfreq=100.0):
+    info = mne.create_info(1, sfreq, "eeg")
+    raw = mne.io.RawArray(np.zeros((1, int(duration * sfreq))), info)
+    raw.set_annotations(annots)
+    return raw
+
+
+def get_results(raw):
+    breaks = [(a["description"], a["onset"], a["onset"] + a["duration"]) for a in raw.annotations if a["description"].startswith("BAD")]
+    return breaks
+
+
+def test_break_removal(capsys):
+    mne.set_log_level("ERROR")
+    base = dict(
+        find_breaks=True,
+        min_break_duration=15.0,
+        t_break_annot_start_after_previous_event=5.0,
+        t_break_annot_stop_before_next_event=5.0,
+        task_event_regex=None,
+        break_start_regex=None,
+        break_end_regex=None,
+    )
+    run = dict(subject="01", session=None, run=None)
+    duration = 300.0
+    sfreq = 100.0
+
+    
+    """ Test break removal by marker detection. """
+    cfg = SimpleNamespace(**{**base, "break_start_regex": r"block\d*_end",
+                        "break_end_regex": r"block\d*_start"})
+
+    # SCENARIO 1.a: break removal by marker with perfectly matching start and end markers"
+    annots = mne.Annotations(
+        [10, 80, 100, 170, 190, 260], [0] * 6,
+        ["block_start", "block_end", "block_start", "block_end", "block_start", "block_end"])
+    raw = make_raw(annots, duration=duration, sfreq=sfreq)
+    _find_breaks_func(cfg=cfg, raw=raw, **run)
+    breaks = get_results(raw)
+    assert breaks == [
+        ("BAD_beginning", 0.0, 10.0),
+        ("BAD_break", 80.0, 100.0),
+        ("BAD_break", 170.0, 190.0),
+        ("BAD_ending", 260.0, duration - 1/sfreq),
+    ]
+
+    # SCENARIO 1.b: break removal by marker with non-matching start and end markers (two block_end (breal_start) in a row)
+    annots = mne.Annotations(
+    [10, 100, 170, 190, 260], [0] * 5,
+    ["block_start", "block_end", "block_end", "block_start", "block_end"])
+    raw = make_raw(annots, duration=duration, sfreq=sfreq)
+    _find_breaks_func(cfg=cfg, raw=raw, **run)
+    breaks = get_results(raw)
+    assert breaks == [
+        ("BAD_beginning", 0.0, 10.0),
+        ("BAD_break", 170.0, 190.0),
+        ("BAD_ending", 260.0, duration - 1/sfreq)
+    ]
+    captured = capsys.readouterr()
+    assert "Found two break starts in a row" in captured.out
+
+    # SCENARIO 1.c: break removal by marker with non-matching start and end markers (two block_start (breal_end) in a row)
+    annots = mne.Annotations(
+    [10, 100, 170, 190, 260], [0] * 5,
+    ["block_start", "block_start", "block_end", "block_start", "block_end"])
+    raw = make_raw(annots, duration=duration, sfreq=sfreq)
+    _find_breaks_func(cfg=cfg, raw=raw, **run)
+    breaks = get_results(raw)
+    assert breaks == [
+        ("BAD_beginning", 0.0, 10.0),
+        ("BAD_break", 170.0, 190.0),
+        ("BAD_ending", 260.0, duration - 1/sfreq)
+    ]
+    captured = capsys.readouterr()
+    assert "Found two break ends in a row" in captured.out
+
+    # SCENARIO 1.d: break removal by marker with overlapping start and end markers
+    raw = make_raw(mne.Annotations(
+        onset=[10, 80, 80, 170, 190, 260], duration=[0] * 6,
+        description=["block_start", "block_end", "block_start", "block_end", "block_start", "block_end"]))
+    _find_breaks_func(cfg=cfg, raw=raw, **run)
+    breaks = get_results(raw)
+    assert breaks == [
+        ("BAD_beginning", 0.0, 10.0),
+        ("BAD_break", 170.0, 190.0),
+        ("BAD_ending", 260.0, duration - 1/sfreq)
+    ]
+    captured = capsys.readouterr()
+    assert "Found two break starts in a row" in captured.out
+    assert "Found two break ends in a row" in captured.out
+
+    # SCENARIO 1.e: break removal by marker with regex matching
+    raw = make_raw(mne.Annotations(
+        onset=[10, 80, 100, 170, 190, 260], duration=[0] * 6,
+        description=["block1_start", "block1_end", "block2_start", "block2_end", "block3_start", "block4_end"]))
+    _find_breaks_func(cfg=cfg, raw=raw, **run)
+    breaks = get_results(raw)
+    assert breaks == [
+        ("BAD_beginning", 0.0, 10.0),
+        ("BAD_break", 80.0, 100.0),
+        ("BAD_break", 170.0, 190.0),
+        ("BAD_ending", 260.0, duration - 1/sfreq)
+    ]
+
+    # SCENARIO 1.f: marker path, clean blocks, regex, no matches (no breaks should be found)
+    raw= make_raw(mne.Annotations(
+    onset=[10, 80, 100, 170, 190, 260], duration=[0] * 6,
+    description=["event1", "event2", "event3", "event4", "event5", "event6"]))
+    _find_breaks_func(cfg=cfg, raw=raw, **run)
+    breaks = get_results(raw)
+    assert breaks == []
+
+
+    """ Test break removal by gap detection. """
+    ann = mne.Annotations(list(np.arange(0, 300, 1.0)) + [10, 250],
+                        [0] * 300 + [0, 0],
+                        ["sync"] * 300 + ["event_1", "event_2"])
+
+    # SCENARIO 2.a: 1 Hz pulses, no event regex defined (pulses hide the break)
+    cfg = SimpleNamespace(**base)
+    raw = make_raw(ann)
+    _find_breaks_func(cfg=cfg, raw=raw, **run)
+    breaks = get_results(raw)
+    assert breaks == []
+
+    # SCENARIO 2.b: 1 Hz pulses, event regex defined (break reappears)
+    cfg = SimpleNamespace(**{**base, "task_event_regex": "event"})
+    raw = make_raw(ann)
+    _find_breaks_func(cfg=cfg, raw=raw, **run)
+    breaks = get_results(raw)
+    assert breaks == [
+       ("BAD_break", 15.0, 245.0), 
+       ("BAD_break", 255.0, 299.99)
+    ]


### PR DESCRIPTION
### Before merging …

- [ ] New break-detection option based on **marker names** added in `_import_data.py` via `[_finds_breaks_func_by_markers]`, allowing for pairing up block/break markers, including trimming the recording start and end
- [ ]  Modifications made on the original `[_finds_breaks_func]` function, allowing for filtering out unwanted (e.g., synchronizing triggers) for duration-based break detection. Function name changed to `[_finds_breaks_func_by_gaps]`. 
- [ ] New `[_finds_breaks_func]` function as a launcher to call either `[_finds_breaks_func_by_markers]` or `[_finds_breaks_func_by_gaps]`
- [ ] Corresponding additions are made in `config.py` ([`break_start_regex`], [`break_start_regex`], [`task_event_regex`])

06.07 edit
- [ ] inside `[_finds_breaks_func_by_markers]`, added the warning for 2 "break_end"s in a row (before: warning only for  2 "break_start"s)
- [ ] added `tests/test_breaks.py`, which include 6 unit tests for `[_finds_breaks_func_by_markers]` and 2 for `[_finds_breaks_func_by_markers]`