### PR TITLE
Exclude breaks for bad channel detection

### DIFF
--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -1373,6 +1373,13 @@ Regular expression used for searching for calibration events
 
 # run bad channel detection
 pyprep_bad_chans: bool = False
+
+pyprep_reject_by_annotation: Literal["omit"] | None = "omit"
+"""
+Whether to include BAD data segments (annotations starting with "BAD" or "bad" e.g. "BAD_break") for the bad channel detection.
+When set to "omit" (Default), BAD data segments will be excluded. When set to "None" the annotations will be ignored.
+"""
+
 ## variables which determine which algos to run
 # run all available algos. if True
 pyprep_all_bads: bool = True

--- a/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
+++ b/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
@@ -503,7 +503,7 @@ def get_config(
         pyprep_by_nan_flat_params=config.pyprep_by_nan_flat_params,
         pyprep_by_ransac=config.pyprep_by_ransac,
         pyprep_by_ransac_params=config.pyprep_by_ransac_params,
-        pyprep_reject_by_annotation,
+        pyprep_reject_by_annotation = config.pyprep_reject_by_annotation,
         # find_bad_channels_extra_kws=config.find_bad_channels_extra_kws,
         **_import_data_kwargs(config=config, subject=subject),
         **extra_kwargs,

--- a/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
+++ b/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
@@ -430,7 +430,12 @@ def _find_bads_pyprep(
 ) -> tuple[list[str], list[str], dict[str, FloatArrayT]]:
     msg = "Finding noisy channels with PyPREP."
     logger.info(**gen_log_kwargs(message=msg))
-    noisy_chans = NoisyChannels(raw, cfg.pyprep_reject_by_annotation)
+    noisy_chans = NoisyChannels(raw, reject_by_annotation=cfg.pyprep_reject_by_annotation)
+    if cfg.pyprep_reject_by_annotation == "omit":
+        msg = "Excluding data segments with bad-annotations e.g. BAD_break for bad channel detection."
+    else:
+        msg = "BAD data segment annotations are ignored for bad channel detection i.e. the full recording is used."
+    logger.info(**gen_log_kwargs(message=msg))
     if cfg.pyprep_all_bads:
         msg = "Running pyprep all bads"
         logger.info(**gen_log_kwargs(message=msg))

--- a/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
+++ b/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
@@ -430,7 +430,7 @@ def _find_bads_pyprep(
 ) -> tuple[list[str], list[str], dict[str, FloatArrayT]]:
     msg = "Finding noisy channels with PyPREP."
     logger.info(**gen_log_kwargs(message=msg))
-    noisy_chans = NoisyChannels(raw)
+    noisy_chans = NoisyChannels(raw, cfg.pyprep_reject_by_annotation)
     if cfg.pyprep_all_bads:
         msg = "Running pyprep all bads"
         logger.info(**gen_log_kwargs(message=msg))
@@ -503,6 +503,7 @@ def get_config(
         pyprep_by_nan_flat_params=config.pyprep_by_nan_flat_params,
         pyprep_by_ransac=config.pyprep_by_ransac,
         pyprep_by_ransac_params=config.pyprep_by_ransac_params,
+        pyprep_reject_by_annotation,
         # find_bad_channels_extra_kws=config.find_bad_channels_extra_kws,
         **_import_data_kwargs(config=config, subject=subject),
         **extra_kwargs,


### PR DESCRIPTION
**Problem:** In the current implementation, the bad channel detection ignores all annotations and thereby will not exclude segments annotated as "BAD_break".

**Solution:** I added a new parameter to the config file to control whether bad segments are excluded in the bad channel detection.

**Design choices:**
- I decided to also use "omit" and None as options because these are the options used by pyprep: https://pyprep.readthedocs.io/en/latest/generated/pyprep.NoisyChannels.html
- However, I do not think they are super intuitive. An alternative could be just using "True" and "False" (I think that's e.g. how it's done in ICA..fit). 
- As default I set "omit", i.e. exclude all segments annotated as "bad" (i.e. having annotations starting with "bad").