### PR TITLE
Add break visualisation

### DIFF
--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -7,6 +7,7 @@ import pandas as pd
 from annotated_types import Ge, Interval, Len, MinLen
 from mne import Covariance
 from mne_bids import BIDSPath
+from mne.io.base import BaseRaw
 
 from mne_bids_pipeline.typing import (
     ArbitraryContrast,
@@ -618,6 +619,61 @@ break *ends* when the next block *begins*.
 ???+ example "Example"
 ```python
     break_end_regex = r"block\\d+_start"
+```
+"""
+
+modify_break_regex_func: Callable[[BaseRaw, str, str], tuple[str, str]] | None = None
+"""
+A custom function to dynamically modify [`break_start_regex`][mne_bids_pipeline._config.break_start_regex] and
+[`break_end_regex`][mne_bids_pipeline._config.break_end_regex] patterns based on any information extracted
+from the `Raw` object or its annotations.
+
+The function must accept the following arguments:
+
+- `raw`: The MNE `Raw` object.
+- `break_start_regex` (str): The current regex pattern for identifying the start of breaks.
+- `break_end_regex` (str): The current regex pattern for identifying the end of breaks.
+
+The function must return a tuple of two regular expressions:
+- The new `break_start_regex` pattern to use.
+- The new `break_end_regex` pattern to use.
+
+A use case could be that there are only break start and stop markers in the data but neither
+block start and stop markers nor start and stop experiment markers. In this case the beginning and ending
+of the recording cannot be automatically annotated as breaks.
+As a solution, start and stop of the experiment can be dynamically added to the regex depending on the first
+and last experimental event markers that have been sent.
+
+???+ example "Example"
+```python
+    # To avoid pickling issues (due to the use of the re package),
+    # define this function in an extra Python file e.g. custom_config_functions.py
+
+    from mne.io.base import BaseRaw
+    from typing import Tuple 
+    import re
+
+    def add_start_and_stop_experiment(
+            raw: BaseRaw,
+            break_start_regex:str,
+            break_end_regex:str
+    ) -> Tuple[str, str]:
+        experiment_events_regex = r".*-trigger=0.*"
+        experiment_annotations = [ann for ann in raw.annotations if re.search(experiment_events_regex, ann["description"])]
+        first_exp_event = re.escape(experiment_annotations[0]["description"])
+        last_exp_event = re.escape(experiment_annotations[-1]["description"])
+
+        break_start_regex_new = break_start_regex + "|" + last_exp_event
+        break_end_regex_new = break_end_regex + "|" + first_exp_event
+
+        return break_start_regex_new, break_end_regex_new
+
+    # In the config file the function is imported
+    import sys
+    sys.path.append("/folder/of/custom_config_functions.py")
+    from custom_config_functions import add_start_and_stop_experiment
+
+    modify_break_regex_func = add_start_and_stop_experiment
 ```
 """
 

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -1373,6 +1373,13 @@ Regular expression used for searching for calibration events
 
 # run bad channel detection
 pyprep_bad_chans: bool = False
+
+pyprep_reject_by_annotation: Literal["omit"] | None = "omit"
+"""
+Whether to include BAD data segments (annotations starting with "BAD" or "bad" e.g. "BAD_break") for the bad channel detection.
+When set to "omit" (Default), BAD data segments will be excluded. When set to "None" the annotations will be ignored.
+"""
+
 ## variables which determine which algos to run
 # run all available algos. if True
 pyprep_all_bads: bool = True

--- a/mne_bids_pipeline/_import_data.py
+++ b/mne_bids_pipeline/_import_data.py
@@ -613,12 +613,20 @@ def _find_breaks_func_by_markers(
     msg = f"Finding breaks between markers {cfg.break_start_regex} and {cfg.break_end_regex}."
     logger.info(**gen_log_kwargs(message=msg))
 
-    # Look for the timesteps where the specified break markers occer in the annotations
+    if cfg.modify_break_regex_func:
+        break_start_regex, break_end_regex = cfg.modify_break_regex_func(raw, cfg.break_start_regex, cfg.break_end_regex)
+        msg = f"The regular expressions have been modified as following: \n Break_start_regex: {break_start_regex} \n Break_end_regex: {break_end_regex}"
+        logger.info(**gen_log_kwargs(message=msg))
+    else:
+        break_start_regex = cfg.break_start_regex
+        break_end_regex = cfg.break_end_regex
+
+    # Look for the timesteps where the specified break markers occur in the annotations
     starts, ends = [], []
     for annot in raw.annotations:
-        if re.search(cfg.break_start_regex, annot["description"]):
+        if re.search(break_start_regex, annot["description"]):
             starts.append(annot["onset"])
-        elif re.search(cfg.break_end_regex, annot["description"]):
+        elif re.search(break_end_regex, annot["description"]):
             ends.append(annot["onset"])
 
     if not starts or not ends:
@@ -968,6 +976,7 @@ def _import_data_kwargs(*, config: SimpleNamespace, subject: str) -> dict[str, A
         break_start_regex=config.break_start_regex,
         break_end_regex=config.break_end_regex,
         task_event_regex=config.task_event_regex,
+        modify_break_regex_func=config.modify_break_regex_func,
         # 6. _rename_events_func
         rename_events=config.rename_events,
         on_rename_missing_events=config.on_rename_missing_events,

--- a/mne_bids_pipeline/_viz.py
+++ b/mne_bids_pipeline/_viz.py
@@ -106,7 +106,7 @@ def visualize_bad_breaks(raw, break_start_regex=None, break_end_regex=None, modi
             regex=True)].index]
 
     
-    fig, ax = plt.subplots(3, 1,figsize=(16, 9), height_ratios=[1,4,1.5])
+    fig, ax = plt.subplots(3, 1,figsize=(10, 7), height_ratios=[1,4,1.5])
 
     # Simple visualisation of break segments in the data (including beginning and end)
     for ann in annotations:

--- a/mne_bids_pipeline/_viz.py
+++ b/mne_bids_pipeline/_viz.py
@@ -3,6 +3,8 @@ from typing import Any
 import numpy as np
 import pandas as pd
 from matplotlib.figure import Figure
+from matplotlib.patches import Rectangle
+import matplotlib.pyplot as plt
 
 
 def plot_auto_scores(
@@ -79,3 +81,96 @@ def plot_auto_scores(
     assert figs
 
     return figs
+
+def visualize_bad_breaks(raw, break_start_regex=None, break_end_regex=None, modify_break_regex_func=None):
+    """Visualization of BAD_break, BAD_ending and BAD_beginning annotations + underlying events"""
+
+    events = raw.annotations.to_data_frame(time_format=None)
+    first_time = raw.first_time
+
+    # If breaks were annotated using break start and end regex, extract potentially modified regex
+    if break_start_regex and break_end_regex:
+        if modify_break_regex_func:
+            break_start_regex_new, break_end_regex_new = modify_break_regex_func(raw, break_start_regex, break_end_regex)
+        else:
+            break_start_regex_new = break_start_regex
+            break_end_regex_new = break_end_regex
+
+        # Extract break annotations together with the underlying break events
+        annotations = raw.annotations[events[events['description'].astype(str).str.contains(
+            f"BAD_break|{break_start_regex_new}|{break_end_regex_new}|BAD_beginning|BAD_ending",
+            regex=True)].index]
+    else: # In the case that breaks were identified using gaps, only use resulting break annotations
+        annotations = raw.annotations[events[events['description'].astype(str).str.contains(
+            f"BAD_break",
+            regex=True)].index]
+
+    
+    fig, ax = plt.subplots(3, 1,figsize=(16, 9), height_ratios=[1,4,1.5])
+
+    # Simple visualisation of break segments in the data (including beginning and end)
+    for ann in annotations:
+        if ann['description'] in ['BAD_break', 'BAD_beginning', 'BAD_ending']:
+            # Draw rectangle for BAD segments
+            rect = Rectangle((ann['onset'], 0), ann['duration'], 1, 
+                        facecolor='red', alpha=0.2, label='Annotated breaks')
+            ax[0].add_patch(rect)
+        else:
+            # Draw vertial line for underlying "break" events
+            ax[0].vlines(ann['onset'], 0, 1, colors='black', label='Underyling break events')
+    
+    
+    ax[0].set_ylim(0, 1)
+    ax[0].set_xlim(raw.times[0]+first_time,raw.times[-1]+first_time) # Add first_time to align with annotation time
+    ax[0].set_xlabel('Time (s)')
+    ax[0].set_yticks([])
+    ax[0].set_title('Break visualisation', loc='left', pad=12)
+
+    
+    handles, labels = ax[0].get_legend_handles_labels()
+    by_label = dict(zip(labels, handles)) # to avoid duplicate labels
+    ax[0].legend(
+        by_label.values(),
+        by_label.keys(),
+        loc="upper left",
+        bbox_to_anchor=(1.,1),
+        frameon=False
+    )
+
+    # Table with additional information (e.g. break onset, duration etc)
+    df_breaks = events[events['description'].astype(str).str.contains(
+        "BAD_break|BAD_beginning|BAD_ending",
+        regex=True)]
+    
+    # Extract table data from DataFrame
+    table_data = df_breaks.values  # Convert DataFrame to NumPy array
+    table_columns = df_breaks.columns  # Get column names
+    
+    # Add a header row to the table data
+    table_data_with_header = [list(table_columns)] + [list(row) for row in table_data]
+    
+    # Add table to the plot
+    table = ax[1].table(
+        cellText=table_data_with_header,
+        cellLoc="center",
+        loc="center",
+        bbox=[0, 0, 1, 1],
+    )
+    ax[1].set_xticks([])
+    ax[1].set_yticks([])
+    ax[1].set_title('Additional information', loc='left', pad=12)
+
+    if break_start_regex and break_end_regex:
+        # Add the regular expressions that were used for the break annotation
+        ax[2].text(
+        0., 1,
+        f"(Modified) break start regex:\n{break_start_regex_new} \n \n (Modified) break end regex:\n{break_end_regex_new}",
+        fontsize=10,
+        verticalalignment="top",
+    )
+        ax[2].set_axis_off()
+        ax[2].set_title("Regular expressions used for break annotation", loc='left', pad=12)
+    
+    fig.tight_layout()
+    
+    return fig

--- a/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
+++ b/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
@@ -503,7 +503,7 @@ def get_config(
         pyprep_by_nan_flat_params=config.pyprep_by_nan_flat_params,
         pyprep_by_ransac=config.pyprep_by_ransac,
         pyprep_by_ransac_params=config.pyprep_by_ransac_params,
-        pyprep_reject_by_annotation,
+        pyprep_reject_by_annotation = config.pyprep_reject_by_annotation,
         # find_bad_channels_extra_kws=config.find_bad_channels_extra_kws,
         **_import_data_kwargs(config=config, subject=subject),
         **extra_kwargs,

--- a/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
+++ b/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
@@ -430,7 +430,12 @@ def _find_bads_pyprep(
 ) -> tuple[list[str], list[str], dict[str, FloatArrayT]]:
     msg = "Finding noisy channels with PyPREP."
     logger.info(**gen_log_kwargs(message=msg))
-    noisy_chans = NoisyChannels(raw, cfg.pyprep_reject_by_annotation)
+    noisy_chans = NoisyChannels(raw, reject_by_annotation=cfg.pyprep_reject_by_annotation)
+    if cfg.pyprep_reject_by_annotation == "omit":
+        msg = "Excluding data segments with bad-annotations e.g. BAD_break for bad channel detection."
+    else:
+        msg = "BAD data segment annotations are ignored for bad channel detection i.e. the full recording is used."
+    logger.info(**gen_log_kwargs(message=msg))
     if cfg.pyprep_all_bads:
         msg = "Running pyprep all bads"
         logger.info(**gen_log_kwargs(message=msg))

--- a/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
+++ b/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
@@ -430,7 +430,7 @@ def _find_bads_pyprep(
 ) -> tuple[list[str], list[str], dict[str, FloatArrayT]]:
     msg = "Finding noisy channels with PyPREP."
     logger.info(**gen_log_kwargs(message=msg))
-    noisy_chans = NoisyChannels(raw)
+    noisy_chans = NoisyChannels(raw, cfg.pyprep_reject_by_annotation)
     if cfg.pyprep_all_bads:
         msg = "Running pyprep all bads"
         logger.info(**gen_log_kwargs(message=msg))
@@ -503,6 +503,7 @@ def get_config(
         pyprep_by_nan_flat_params=config.pyprep_by_nan_flat_params,
         pyprep_by_ransac=config.pyprep_by_ransac,
         pyprep_by_ransac_params=config.pyprep_by_ransac_params,
+        pyprep_reject_by_annotation,
         # find_bad_channels_extra_kws=config.find_bad_channels_extra_kws,
         **_import_data_kwargs(config=config, subject=subject),
         **extra_kwargs,

--- a/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
+++ b/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
@@ -114,6 +114,36 @@ def assess_data_quality(
             cfg=cfg,
             data_is_rest=data_is_rest,
         )
+
+        # If break annotation was used, visualize breaks
+        if cfg.find_breaks:
+            from mne_bids_pipeline._viz import visualize_bad_breaks
+            break_fig = visualize_bad_breaks(raw, cfg.break_start_regex, cfg.break_end_regex, cfg.modify_break_regex_func)
+
+            msg = "Adding break annotation visualization to the report."
+            logger.info(**gen_log_kwargs(message=msg))
+            with _open_report(
+                cfg=cfg,
+                exec_params=exec_params,
+                subject=subject,
+                session=session,
+                run=run,
+                task=cfg.task,
+            ) as report:
+                caption = "Visualization of break annotations."
+                report.add_figure(
+                    fig=break_fig,
+                    title="Visualization of break annotations",
+                    #section="ICA: nan removal",
+                    caption=caption,
+                    tags=("breaks"),
+                    replace=True,
+                )
+                plt.close(break_fig)
+
+
+
+
     preexisting_bads = sorted(raw.info["bads"])
 
     auto_scores: dict[str, FloatArrayT] | None = None
@@ -486,6 +516,10 @@ def get_config(
         )
         extra_kwargs["mf_head_origin"] = config.mf_head_origin
     cfg = SimpleNamespace(
+        # find_breaks=config.find_breaks,
+        # break_start_regex=config.break_start_regex,
+        # break_end_regex=config.break_end_regex,
+        # modify_break_regex_func=config.modify_break_regex_func,
         # These are included in _import_data_kwargs for automatic add_bads
         # detection
         # find_flat_channels_meg=config.find_flat_channels_meg,


### PR DESCRIPTION
I created a visualisation for the break annotation.
<img width="2016" height="788" alt="grafik" src="https://github.com/user-attachments/assets/e7ab2407-ba6f-4fb4-a395-d02b37125d82" />


However, this branch already contains the changes from the `hook-for-dynamic-break-regex` and the `exlude-breaks-for-bad-channel-detection` branches.
If we don't want to merge them we can do some cherry picking to only add the visualisation.

@QIANYUE-LIII So far I only tested the case in which I use the break detection using markers (plus my additional break regex modification function)- Could you please test on some data whether the visualisation also works in the case of annotating breaks by gaps and without my regex modification function?

If anything is unclear, please let me know.